### PR TITLE
Jelly Chart 버그 수정

### DIFF
--- a/demo/bubble-xy-heatmap.html
+++ b/demo/bubble-xy-heatmap.html
@@ -215,6 +215,7 @@
     ]).dimensions(['category', 'name'])
     .measures('value')
     .axis('x').axis('y')
+    .label(true)
     .shape('bubble-heatmap')
     .legend(true)
     .render();</code></pre>
@@ -241,6 +242,7 @@
             ]).dimensions(['category', 'name'])
           .measures('value')
           .axis('x').axis('y')
+          .label(true)
           .shape('bubble-heatmap')
           .legend(true)
           .render();

--- a/demo/sort-value-xyheatmap.html
+++ b/demo/sort-value-xyheatmap.html
@@ -215,6 +215,7 @@
   .measures('value')
   .sortByValue('ascending')
   .axis('x').axis('y')
+  .label(true)
   .legend(true)
   .render();</code></pre>
     
@@ -241,6 +242,7 @@
   .measures('value')
   .sortByValue('ascending')
   .axis('x').axis('y')
+  .label(true)
   .legend(true)
   .render();
       }, 200);

--- a/demo/src/xy-heatmap/bubble-xy-heatmap/index.js
+++ b/demo/src/xy-heatmap/bubble-xy-heatmap/index.js
@@ -19,6 +19,7 @@ jelly.xyHeatmap().container('#jelly-container')
     ]).dimensions(['category', 'name'])
     .measures('value')
     .axis('x').axis('y')
+    .label(true)
     .shape('bubble-heatmap')
     .legend(true)
     .render();

--- a/demo/src/xy-heatmap/xy-heatmap/index.js
+++ b/demo/src/xy-heatmap/xy-heatmap/index.js
@@ -11,5 +11,6 @@ jelly.xyHeatmap().container('#jelly-container')
   ]).dimensions(['category', 'name'])
   .measures('value')
   .axis('x').axis('y')
+  .label(true)
   .legend(true)
   .render();

--- a/demo/xy-heatmap.html
+++ b/demo/xy-heatmap.html
@@ -214,6 +214,7 @@
   ]).dimensions(['category', 'name'])
   .measures('value')
   .axis('x').axis('y')
+  .label(true)
   .legend(true)
   .render();</code></pre>
     
@@ -239,6 +240,7 @@
   ]).dimensions(['category', 'name'])
   .measures('value')
   .axis('x').axis('y')
+  .label(true)
   .legend(true)
   .render();
       }, 200);

--- a/src/layouts/pivot-table/_mark.js
+++ b/src/layouts/pivot-table/_mark.js
@@ -146,7 +146,7 @@ function _mark() {
     let dataGrid = selection.selectAll(that.nodeName(true)).data(d => d.children, d => d.data.key);
     dataGrid.exit().remove();
     let dataGridEnter = dataGrid.enter().append('g')
-        .attr('class', that.nodeName(true))
+        .attr('class', that.nodeName(true) + ' point')
         .call(__local);
     dataGridEnter.append('rect')
         .call(__dataGrid);

--- a/src/layouts/pivot-table/_mark.js
+++ b/src/layouts/pivot-table/_mark.js
@@ -89,6 +89,7 @@ function _mark() {
     selection
         .attr('width', width)
         .attr('height', height)
+        .style('stroke', borderColor)
         .style('fill', d => d.color);
   }
 

--- a/src/layouts/pivot-table/_tooltip.js
+++ b/src/layouts/pivot-table/_tooltip.js
@@ -1,6 +1,5 @@
 function _tooltip() {
   if(!this.tooltip()) return;
-  // const field = this.__execs__.field;
 
   const innerSize = this.innerSize();
   const scale = this.__execs__.scale;
@@ -11,7 +10,6 @@ function _tooltip() {
 
   let value = function(d, text) {
     return {name: d.data.key, value: text};
-    // return {name: field.color.field(), value: text};
   }
   let offset = function(_, i) {
     let x = innerSize.width / (scale.x.domain().length + 1);

--- a/src/layouts/xy-heatmap/_mark.js
+++ b/src/layouts/xy-heatmap/_mark.js
@@ -3,7 +3,6 @@ import {labelFormat, className} from '../../modules/util';
 
 function _mark() {
   const that = this;
-  const innerSize = this.innerSize();
   const shape = this.shape();
   const munged = this.__execs__.munged;
   const canvas = this.__execs__.canvas;
@@ -145,7 +144,9 @@ function _mark() {
   let __subLabel = function(selection) {
     selection.each(function (d) {
       let selection = select(this);
-      selection.text(labelFormat((d.value / d.total), false, ',.1%'));
+      selection
+        .style('visibility', label ? 'visible' : 'hidden')
+        .text(labelFormat((d.value / d.total), false, ',.1%'));
 
       let textArea = selection.node().getBoundingClientRect();
       if (shape === 'heatmap') {


### PR DESCRIPTION
1. 피봇테이블 차트에서 borderColor가 헤더에만 적용되는 버그 수정
2. 피봇테이블 차트에서 노드에 마우스 오버 시 범례에 해당 값 위치가 표시 되지 않는 버그 수정
3. 히트맵 차트에서 레이블이 정상적으로 표시되지 않는 문제 수정